### PR TITLE
fix!: turn off preload tag option by default

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -26,7 +26,7 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
     text: null,
     prefetch: true,
     preconnect: true,
-    preload: true,
+    preload: false,
     useStylesheet: false,
     download: false,
     base64: false,

--- a/test/basic.test.ts
+++ b/test/basic.test.ts
@@ -21,9 +21,9 @@ describe('basic', () => {
     expect(body).toContain('<link data-n-head="ssr" data-hid="gf-origin-preconnect" rel="preconnect" href="https://fonts.googleapis.com/">')
   })
 
-  test('has preload link', async () => {
+  test('does not have preload link by default', async () => {
     const { body } = await get('/')
-    expect(body).toContain('<link data-n-head="ssr" data-hid="gf-preload" rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Roboto&amp;family=Lato">')
+    expect(body).not.toContain('<link data-n-head="ssr" data-hid="gf-preload" rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Roboto&amp;family=Lato">')
   })
 
   test('no has stylesheet link', async () => {

--- a/test/fixture/use-stylesheet/nuxt.config.js
+++ b/test/fixture/use-stylesheet/nuxt.config.js
@@ -12,6 +12,7 @@ export default {
     families: {
       Roboto: true
     },
-    useStylesheet: true
+    useStylesheet: true,
+    preload: true
   }
 }

--- a/test/use-stylesheet.test.ts
+++ b/test/use-stylesheet.test.ts
@@ -16,7 +16,7 @@ describe('use stylesheet', () => {
     expect(body).toContain('<link data-n-head="ssr" data-hid="gf-preconnect" rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">')
   })
 
-  test('has preload link', async () => {
+  test('has preload link (enabled in config)', async () => {
     const { body } = await get('/')
     expect(body).toContain('<link data-n-head="ssr" data-hid="gf-preload" rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Roboto&amp;family=Lato">')
   })


### PR DESCRIPTION
This commit turns off preload tag generation for
Google Fonts by default because:
  - generally preconnect tags should be sufficient
  - adding preloads as well runs the risk of resource
    contention with more critical resources
  - preloads don't take into account font unicode
    ranges, which could be problematic for i18n

See more here: https://web.dev/font-best-practices/#avoid-using-preload-to-load-fonts