### PR TITLE
feat!: turn on font stylesheet inlining by default

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -28,7 +28,7 @@ const nuxtModule: Module<ModuleOptions> = function (moduleOptions) {
     preconnect: true,
     preload: true,
     useStylesheet: false,
-    download: false,
+    download: true,
     base64: false,
     inject: true,
     overwriting: false,

--- a/test/fixture/basic/nuxt.config.js
+++ b/test/fixture/basic/nuxt.config.js
@@ -11,6 +11,7 @@ export default {
   googleFonts: {
     families: {
       Roboto: true
-    }
+    },
+    download: false
   }
 }

--- a/test/fixture/download/nuxt.config.js
+++ b/test/fixture/download/nuxt.config.js
@@ -4,7 +4,6 @@ export default {
     '../../../src/module.ts'
   ],
   googleFonts: {
-    download: true,
     families: {
       Roboto: true
     }

--- a/test/fixture/use-stylesheet/nuxt.config.js
+++ b/test/fixture/use-stylesheet/nuxt.config.js
@@ -12,6 +12,7 @@ export default {
     families: {
       Roboto: true
     },
-    useStylesheet: true
+    useStylesheet: true,
+    download: false
   }
 }


### PR DESCRIPTION
This commit enables the "download" option by default,
which turns on inlining of the font stylesheet and
the downloading/self-hosting of the font. As these
are both best practices, it makes sense for these
to be part of the default experience.

See more: https://web.dev/font-best-practices/#inline-font-declarations